### PR TITLE
34 create a tag

### DIFF
--- a/Tabloid/Controllers/TagController.cs
+++ b/Tabloid/Controllers/TagController.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Tabloid.Repositories;
+using Tabloid.Models;
 
 // For more information on enabling Web API for empty projects, visit https://go.microsoft.com/fwlink/?LinkID=397860
 
@@ -25,18 +26,20 @@ namespace Tabloid.Controllers
             return Ok(alphabetizedTags);
         }
 
+        // POST api/<TagController>
+        [HttpPost]
+        public IActionResult Post(Tag tag)
+        {
+            _tagRepository.Add(tag);
+            return CreatedAtAction(nameof(Get), new { id = tag.Id }, tag);
+        }
+
         /*Ignore these for now
         // GET api/<TagController>/5
         [HttpGet("{id}")]
         public string Get(int id)
         {
             return "value";
-        }
-
-        // POST api/<TagController>
-        [HttpPost]
-        public void Post([FromBody] string value)
-        {
         }
 
         // PUT api/<TagController>/5

--- a/Tabloid/Repositories/ITagRepository.cs
+++ b/Tabloid/Repositories/ITagRepository.cs
@@ -6,5 +6,6 @@ namespace Tabloid.Repositories
     public interface ITagRepository
     {
         List<Tag> GetAll();
+        void Add(Tag tag);
     }
 }

--- a/Tabloid/Repositories/TagRepository.cs
+++ b/Tabloid/Repositories/TagRepository.cs
@@ -47,5 +47,23 @@ namespace Tabloid.Repositories
                 Name = DbUtils.GetString(reader, "Name")
             };
         }
+
+        public void Add(Tag tag)
+        {
+            using (var conn = Connection)
+            {
+                conn.Open();
+                using (var cmd = conn.CreateCommand())
+                {
+                    cmd.CommandText = @"INSERT INTO Tag ([Name])
+                                        OUTPUT INSERTED.ID
+                                        VALUES (@name)";
+
+                    DbUtils.AddParameter(cmd, "@name", tag.Name);
+
+                    tag.Id = (int)cmd.ExecuteScalar();
+                }
+            }
+        }
     }
 }

--- a/Tabloid/appsettings.json
+++ b/Tabloid/appsettings.json
@@ -8,6 +8,6 @@
   },
   "AllowedHosts": "*",
   "ConnectionStrings": {
-    "DefaultConnection": "server=localhost\\SQLExpress07;database=Tabloid;integrated security=true"
+    "DefaultConnection": "server=localhost\\SQLExpress;database=Tabloid;integrated security=true"
   }
 }

--- a/Tabloid/client/package.json
+++ b/Tabloid/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tabloid-client",
-  "proxy": "https://localhost:44360",
+  "proxy": "https://localhost:5001",
   "version": "0.1.0",
   "private": true,
   "dependencies": {

--- a/Tabloid/client/src/components/ApplicationViews.js
+++ b/Tabloid/client/src/components/ApplicationViews.js
@@ -9,6 +9,7 @@ import PostList from './PostList'
 import CategoryList from './CategoryList'
 import CategoryAddForm from './CategoryAddForm'
 import PostDetail from './PostDetail'
+import TagAddForm from './TagAddForm'
 
 export default function ApplicationViews({ isLoggedIn }) {
   return (
@@ -26,6 +27,7 @@ export default function ApplicationViews({ isLoggedIn }) {
                 isLoggedIn ? <TagList /> : <p>Whoops, nothing here...</p>
               }
             />
+            <Route path="add" element={isLoggedIn ? <TagAddForm /> : <p>Whoops, nothing here...</p>} />
           </Route>
           <Route path="category">
             <Route

--- a/Tabloid/client/src/components/TagAddForm.js
+++ b/Tabloid/client/src/components/TagAddForm.js
@@ -1,0 +1,50 @@
+import React, { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { Button, Form, FormGroup, Label, Input, Card, CardHeader, CardTitle, CardBody } from "reactstrap";
+import { addTag } from "../modules/tagManager";
+
+export default function TagAddForm() {
+    const [tagName, setTagName] = useState("")
+    const navigate = useNavigate();
+
+    const submitForm = (event) => {
+        event.preventDefault();
+        addTag({ name: tagName })
+            .then(() => navigate("/tag/manager"))
+    }
+
+    return (
+        <Card style={{
+            display: 'block',
+            width: 700,
+            padding: 30
+        }}>
+            <Form onSubmit={submitForm}>
+                <FormGroup>
+                    <CardTitle>
+                        <h3>
+                            New Tag
+                        </h3>
+                    </CardTitle>
+                    <CardBody>
+
+                        <Label for="TagName">
+                            <h5>
+                                Tag Name:
+                            </h5>
+                        </Label>
+                        <br></br>
+                        <Input
+                            id="TagName"
+                            type="textarea"
+                            onChange={(event) => setTagName(event.target.value)}
+                        />
+                    </CardBody>
+                </FormGroup>
+                <FormGroup>
+                    <Button>Save</Button>
+                </FormGroup>
+            </Form>
+        </Card >
+    )
+}

--- a/Tabloid/client/src/components/TagList.js
+++ b/Tabloid/client/src/components/TagList.js
@@ -9,7 +9,7 @@ export default function TagManager() {
 
     const handleClick = () => {
 
-        navigate("/add")
+        navigate("/tag/add")
     }
 
     useEffect(() => {

--- a/Tabloid/client/src/modules/tagManager.js
+++ b/Tabloid/client/src/modules/tagManager.js
@@ -19,3 +19,26 @@ export const getAllTags = () => {
         })
     })
 }
+
+export const addTag = (tag) => {
+    return getToken().then((token) => {
+        return fetch(apiUrl, {
+            method: "POST",
+            headers: {
+                Authorization: `Bearer ${token}`,
+                "Content-Type": "application/json"
+            },
+            body: JSON.stringify(tag)
+        }).then((res) => {
+            if (res.ok) {
+                return res.json();
+            }
+            else if (res.status === 401) {
+                throw new Error("Unauthorized");
+            }
+            else {
+                throw new Error("An unknow error occurred while trying to create a tag.")
+            }
+        })
+    })
+}


### PR DESCRIPTION
## What?
Gave users the ability to add a new tag. This feature will be useful for users who want to indicate the content of a post in short form. These changes are pursuant to issue ticket #34 
## Why?
This feature is vital to the user experience. Without these quick tags, they rely on a post's category to determine whether they are interested in the content. Tags are more specific and each post can have multiple tags. A post can only have one broad category at a time.
## How?
Create an API endpoint that creates a new tag entry in the database. Created a button on the client side that links to a new form. When users click the button, a POST request is sent to the API endpoint
## Testing?
Tested api via postman. Tested full feature on client side multiple times. All worked as expected